### PR TITLE
readme_renderer 44.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/nh3-feedstock/pr1/3504127

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/nh3-feedstock/pr1/3504127

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
 {% set name = "readme_renderer" %}
-{% set version = "40.0" %}
+{% set version = "44.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9f77b519d96d03d7d7dce44977ba543090a14397c4f60de5b6eb5b8048110aa4
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -20,22 +21,28 @@ requirements:
     - wheel
     - setuptools
   run:
-    - bleach >=2.1.0
-    - cmarkgfm >=0.8.0
-    - docutils >=0.13.1
-    - pygments >=2.5.1
     - python
+    - nh3 >=0.2.14
+    - docutils >=0.21.2
+    - pygments >=2.5.1
+  run_constrained:
+    # md
+    - cmarkgfm >=0.8.0
 
 test:
-  requires:
-    - pip
+  source_files:
+    - tests
+    - README.rst
   imports:
     - readme_renderer
-  source_files:
-    - README.rst
   commands:
     - pip check
-    - python -m readme_renderer README.rst
+    # test_rst_fixtures[test_rst_008.rst]
+    # E   Module not found 'types_docutils' -> https://pypi.org/project/types-docutils
+    - pytest -v tests --deselect=tests/test_rst.py::test_rst_fixtures[test_rst_008
+  requires:
+    - pip
+    - pytest
 
 about:
   home: https://github.com/pypa/readme_renderer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,8 @@ requirements:
 
 test:
   source_files:
-    - tests
     - README.rst
+    - tests
   imports:
     - readme_renderer
   commands:


### PR DESCRIPTION
readme_renderer 44.0 

**Destination channel:** Defaults

### Links

- [PKG-10503]
- dev_url:        https://github.com/pypa/readme_renderer/tree/44.0
- conda_forge:    https://github.com/conda-forge/readme_renderer-feedstock
- pypi:           https://pypi.org/project/readme_renderer/44.0
- pypi inspector: https://inspector.pypi.io/project/readme_renderer/44.0

### Explanation of changes:

- new version number


[PKG-10503]: https://anaconda.atlassian.net/browse/PKG-10503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ